### PR TITLE
Prevent disposable starvation when number of stalled entries is too large

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/resourcedisposer/AsyncResourceDisposer.java
+++ b/src/main/java/org/jenkinsci/plugins/resourcedisposer/AsyncResourceDisposer.java
@@ -33,10 +33,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -51,7 +49,6 @@ import hudson.util.ExceptionCatchingThreadFactory;
 import hudson.util.HttpResponses;
 import hudson.util.NamingThreadFactory;
 import jenkins.model.Jenkins;
-import jenkins.util.ContextResettingExecutorService;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -111,16 +108,7 @@ public class AsyncResourceDisposer extends AdministrativeMonitor implements Seri
 
     private Object readResolve() {
         if (worker == null) {
-            worker = new ContextResettingExecutorService(
-                    new ThreadPoolExecutor(
-                            0, MAXIMUM_POOL_SIZE,
-                            60L, TimeUnit.SECONDS,
-                            new SynchronousQueue<>(),
-                            THREAD_FACTORY,
-                            // Ignore all WorkItems that does not fit into the pool to be rescheduled later
-                            new ThreadPoolExecutor.DiscardPolicy()
-                    )
-            );
+            worker = Executors.newFixedThreadPool(MAXIMUM_POOL_SIZE, THREAD_FACTORY);
         }
         return this;
     }


### PR DESCRIPTION
Old executor service implementation took MAXIMUM_POOL_SIZE items every minute to
processed them. With enough stalled items cumulated at the beginning of the
disposable set, they would occupy all the slots preventing recent (and possibly easily
disposable) items to ever run prolonging the resource disposal.

The new implementation will schedule all disposables every minute using MAXIMUM_POOL_SIZE
concurrency level to void that.