### PR TITLE
Remove explicit dependency to jenkins-core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,20 +55,6 @@
       <version>1.4.7-jenkins-2</version>
     </dependency>
     -->
-
-    <!-- enforcer complains about dependency provided by core -->
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <version>${jenkins.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-guice</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
   </dependencies>
 
   <repositories>


### PR DESCRIPTION
It introduces issues when using custom-war-packager - see jenkinsci/custom-war-packager#126. And it seems that having an explicit dependency to jenkins-core is not needed - enforcer does not fail the build, as suggested by the comment.