### PR TITLE
Make stack trace theme aware

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/resourcedisposer/Disposable/State/Thrown/cell.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/resourcedisposer/Disposable/State/Thrown/cell.groovy
@@ -41,7 +41,7 @@ st.once {
                     .stacktrace .full {
                         visibility: hidden;
                         position: absolute;
-                        background: #ddd;
+                        background: var(--light-bg-color, #ddd);
 
                         top: -5px; left: -4px;
                         border: solid 1px #bbb;


### PR DESCRIPTION
This also changes the light theme background from #ddd to #eee, but I don't think this is a big deal either way.

**Screenshots**
<details><summary>Before</summary>

![image](https://user-images.githubusercontent.com/5424257/94879137-fb6e2200-0491-11eb-87e7-c9dcf6319049.png)

</details>

<details><summary>After</summary>

![image](https://user-images.githubusercontent.com/5424257/94879091-d679af00-0491-11eb-8839-fa1726300f43.png)

</details>

css `var` is unsupported in IE (Supported in Edge), so let me know if this is a requirement and I'll add an IE workaround.