### PR TITLE
Replace string literal '&amp;nbsp;' with '&nbsp;'

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/resourcedisposer/AsyncResourceDisposer/index.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/resourcedisposer/AsyncResourceDisposer/index.groovy
@@ -40,7 +40,7 @@ l.layout(permission: app.ADMINISTER) {
                 th(_("Resource"))
                 th(_("State"))
                 th(_("Tracked since"))
-                th("&nbsp;")
+                th(st.nbsp())
             }
             DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm")
             for (AsyncResourceDisposer.WorkItem item in my.backlog) {


### PR DESCRIPTION
Jelly automatically escapes '&', resulting in the string "&nbsp;" being displayed (see right of "Tracked since").

Unsure if this is the way to fix it, but I'll see what the build system does.

![image](https://user-images.githubusercontent.com/5424257/94885442-bd2d2e80-04a2-11eb-9c6d-fa6874115b03.png)