### PR TITLE
PersistenceTest#persistEntries is flaky

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/resourcedisposer/PersistenceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/resourcedisposer/PersistenceTest.java
@@ -52,9 +52,9 @@ public class PersistenceTest {
     @Test
     public void persistEntries() {
         j.addStep(new Statement() {
-            @Override public void evaluate() {
+            @Override public void evaluate() throws Exception {
                 AsyncResourceDisposer disposer = AsyncResourceDisposer.get();
-                disposer.disposeAndWait(new FailingDisposable());
+                disposer.disposeAndWait(new FailingDisposable()).get();
                 AsyncResourceDisposer.WorkItem item = checkItem(disposer.getBacklog());
 
                 assertThat(item.getLastState(), instanceOf(Thrown.class));


### PR DESCRIPTION
## Problem

As observed [here](https://ci.jenkins.io/job/Plugins/job/resource-disposer-plugin/job/master/16/consoleFull), [here](https://ci.jenkins.io/job/Plugins/job/resource-disposer-plugin/job/PR-5/1/consoleFull), and [here](https://ci.jenkins.io/job/Plugins/job/resource-disposer-plugin/job/PR-8/1/consoleFull), `PersistenceTest#persistEntries` periodically flakes with:

```
[ERROR] persistEntries(org.jenkinsci.plugins.resourcedisposer.PersistenceTest)  Time elapsed: 0.563 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: an instance of org.jenkinsci.plugins.resourcedisposer.Disposable$State$Thrown
     but: <org.jenkinsci.plugins.resourcedisposer.Disposable$State$ToDispose@420a87b6> is a org.jenkinsci.plugins.resourcedisposer.Disposable$State$ToDispose
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
        at org.jenkinsci.plugins.resourcedisposer.PersistenceTest$1.evaluate(PersistenceTest.java:60)
        at org.jvnet.hudson.test.RestartableJenkinsRule$6.evaluate(RestartableJenkinsRule.java:240)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:552)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.lang.Thread.run(Thread.java:748)
```

## Evaluation

When I add

```
diff --git a/src/test/java/org/jenkinsci/plugins/resourcedisposer/FailingDisposable.java b/src/test/java/org/jenkinsci/plugins/resourcedisposer/FailingDisposable.java
index 9eb69b8..33cbcab 100644
--- a/src/test/java/org/jenkinsci/plugins/resourcedisposer/FailingDisposable.java
+++ b/src/test/java/org/jenkinsci/plugins/resourcedisposer/FailingDisposable.java
@@ -37,6 +37,7 @@ class FailingDisposable implements Disposable {
 
     @Nonnull @Override
     public State dispose() throws Exception {
+        Thread.sleep(5000);
         throw EXCEPTION;
     }
```

I can consistently reproduce the error.

`AsyncResourceDisposer#disposeAndWait`, a method designed specifically for use from tests, returns `Future<WorkItem>`, which tests are expected to call `.get()` on. All tests expect for `PersistenceTest#persistEntries` do this.

## Solution

Call `.get()` on the `Future<WorkItem>` returned by `AsyncResourceDisposer#disposeAndWait` in `PersistenceTest#persistEntries`.

CC @olivergondza 